### PR TITLE
add mauiserver to api-pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ match the namespace you created earlier). Here is example `example-custom-values
 ```yaml
 ingressType: Route
 ingressHost: example-annif-utils.rahtiapp.fi
+securityContext: {}
 ```
 
 Deploy with Helm, using our custom values:

--- a/helm_charts/annif-utils/templates/api-deployment.yaml
+++ b/helm_charts/annif-utils/templates/api-deployment.yaml
@@ -18,23 +18,38 @@ spec:
         app: annif
       name: api
     spec:
-      # download project data if defined
-      {{- if .Values.projectsTarballUrl }}
       initContainers:
+        # copy tomcat webapps to a local scratch volume for write access
+        - name: prepare-maiuserver-webapps
+          image: {{ .Values.apiImageMauiserver }}
+          volumeMounts:
+            - mountPath: /webapps
+              name: tomcat-temp
+              subPath: webapps
+          command: ["/bin/bash"]
+          args:
+            - -c
+            - cp -r /usr/local/tomcat/webapps/* /webapps/.
+      {{- if .Values.projectsTarballUrl }}
+        # download project data if download url is defined and a successful download has not been done before
         - name: project-downloader
-          image: {{ .Values.apiImage }}
+          image: {{ .Values.apiImageAnnif }}
           volumeMounts:
             - mountPath: /annif-projects
               name: annif-vol
           command: ["/bin/bash"]
           args:
             - -c
-            - curl {{ .Values.projectsTarballUrl }} | tar xz -C /annif-projects
+            - >
+              if [[ ! -e /annif-projects/DOWNLOAD_SUCCESSFUL ]]; then
+                curl {{ .Values.projectsTarballUrl }} | tar xz -C /annif-projects;
+                date -Is > /annif-projects/DOWNLOAD_SUCCESSFUL;
+              fi
       {{- end }}
       containers:
-        - name: api
+        - name: annif
           env: []
-          image: {{ .Values.apiImage }}
+          image: {{ .Values.apiImageAnnif }}
           imagePullPolicy: {{ .Values.apiImagePullPolicy }}
           command: ["annif"]
           args:
@@ -45,7 +60,7 @@ spec:
               cpu: 100m
               memory: 200Mi
             limits:
-              cpu: 1900m
+              cpu: 1000m
               memory: 4Gi
           ports:
             - containerPort: 5000
@@ -64,7 +79,52 @@ spec:
           volumeMounts:
             - mountPath: /annif-projects
               name: annif-vol
+
+        - name: mauiserver
+          image: {{ .Values.apiImageMauiserver }}
+          imagePullPolicy: {{ .Values.apiImagePullPolicy }}
+          env: []
+          command:
+            - catalina.sh
+            - run
+          resources:
+            requests:
+              cpu: 100m
+              memory: 200Mi
+            limits:
+              cpu: 1000m
+              memory: 4Gi
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 30
+            timeoutSeconds: 3
+          readinessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 3
+            timeoutSeconds: 3
+          volumeMounts:
+            - mountPath: /mauidata
+              name: annif-vol
+              subPath: mauidata
+            - mountPath: /usr/local/tomcat/conf/Catalina/localhost
+              name: tomcat-temp
+              subPath: conf_Catalina_localhost
+            - mountPath: /usr/local/tomcat/webapps
+              name: tomcat-temp
+              subPath: webapps
+          ports:
+            - containerPort: 8080
+
       volumes:
+        # persistent volume for data
         - name: annif-vol
           persistentVolumeClaim:
             claimName: annif-pvc
+        # temporary volume for mauiserver for directories that need to be writable
+        - name: tomcat-temp
+          emptyDir: {}
+      {{ if .Values.securityContext }}
+      securityContext: {{ .Values.securityContext }}
+      {{ end }}

--- a/helm_charts/annif-utils/templates/api-ingress-annif.yaml
+++ b/helm_charts/annif-utils/templates/api-ingress-annif.yaml
@@ -2,9 +2,10 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: api
+  name: api-annif
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
   labels:
     app: annif
 spec:
@@ -12,8 +13,8 @@ spec:
     - host: {{ .Values.ingressHost }}
       http:
         paths:
-          - backend:
+          - path: /annif(/|$)(.*)
+            backend:
               serviceName: api
               servicePort: 5000
-
 {{- end}}

--- a/helm_charts/annif-utils/templates/api-ingress-mauiserver.yaml
+++ b/helm_charts/annif-utils/templates/api-ingress-mauiserver.yaml
@@ -1,0 +1,20 @@
+{{- if eq .Values.ingressType "Ingress" }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: api-mauiserver
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+  labels:
+    app: annif
+spec:
+  rules:
+    - host: {{ .Values.ingressHost }}
+      http:
+        paths:
+          - path: /mauiserver
+            backend:
+              serviceName: api
+              servicePort: 8080
+
+{{- end}}

--- a/helm_charts/annif-utils/templates/api-route-annif.yaml
+++ b/helm_charts/annif-utils/templates/api-route-annif.yaml
@@ -1,0 +1,23 @@
+{{- if eq .Values.ingressType "Route" }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: annif
+  labels:
+    app: annif
+spec:
+  {{- if .Values.ingressHost }}
+  host: {{ .Values.ingressHost }}
+  {{- end }}
+  to:
+    kind: Service
+    name: api
+    weight: 100
+  port:
+    targetPort: annif
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+status:
+  ingress: []
+{{- end}}

--- a/helm_charts/annif-utils/templates/api-route-mauiserver.yaml
+++ b/helm_charts/annif-utils/templates/api-route-mauiserver.yaml
@@ -2,19 +2,20 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: api
+  name: mauiserver
   labels:
     app: annif
 spec:
   {{- if .Values.ingressHost }}
   host: {{ .Values.ingressHost }}
   {{- end }}
+  path: /mauiserver
   to:
     kind: Service
     name: api
     weight: 100
   port:
-    targetPort: api
+    targetPort: mauiserver
   tls:
     insecureEdgeTerminationPolicy: Redirect
     termination: edge

--- a/helm_charts/annif-utils/templates/api-service.yaml
+++ b/helm_charts/annif-utils/templates/api-service.yaml
@@ -8,8 +8,11 @@ metadata:
     app: annif
 spec:
   ports:
-    - name: api
+    - name: annif
       port: 5000
       targetPort: 5000
+    - name: mauiserver
+      port: 8080
+      targetPort: 8080
   selector:
     name: api

--- a/helm_charts/annif-utils/values.yaml
+++ b/helm_charts/annif-utils/values.yaml
@@ -2,12 +2,13 @@
 # ProjectTarballUrl refers to tar.gz package containing data directory and project configuration file.
 
 # images
-apiImage: quay.io/natlibfi/annif:latest
+apiImageAnnif: quay.io/natlibfi/annif:latest
+apiImageMauiserver: quay.io/natlibfi/mauiserver:latest
 
 # To avoid remote pulling with local kubernetes, you can set this to 'IfNotPresent'
 apiImagePullPolicy: Always
 
-# Replica counts for api and worker
+# Replica counts for api
 apiReplicas: 1
 
 # Ingress type can be 'Ingress' for Kubernetes ingresses or 'Route' for OpenShift Routes
@@ -16,7 +17,10 @@ ingressType: Ingress
 # Ingress host, 'localhost' works on Docker/Kubernetes. Change if you need external cluster
 ingressHost: localhost
 
+# Set non-root user in local Kubernetes
+securityContext: "{ runAsUser: 65534,  runAsGroup: 0 }"
+
 # ----------------------------------------------------------------------------
 # Application content
 
-projectsTarballUrl: << url to the tar package >>
+#projectsTarballUrl: << url to the tar package >>


### PR DESCRIPTION
Add mauiserver as a second container to the pod. Support starting the
container as non-root. Make project data downloading smarter.

Changes:

- deployment
  - rename annif container (api -> annif)
  - use the same data volume as annif
  - add an init container for moving tomcat webapps to a writable volume
  - skip downloading project data if it has been successfully downloaded
    before
  - change the application limits so that both containers fit in Rahti
  - add a container for mauiserver, listening on 8080
  - add a scratch volume for writable directories in mauiserver
  - add securityContext to specify a non-root user when running locally

- ingresses and routes
  - rename annif resources (api -> annif)
  - create ingress and route for mauiserver, passing /mauiserver path
    upstream
  - modify annif ingress
    - change path to /annif to isolate annif from other applications
      running on the same ingress, e.g. localhost
    - use rewrite-target annotation to remove /annif/ from upstream
      requests
- add mauiserver port to service
- values.yaml
  - rename annif image to apiImageAnnif
  - add mauiserver image apiImageMauiserver
  - add securityContext to specify non-root user for local K8s
  - comment projectsTarballUrl out by default, since the value was not
    valid
- added empty securityContext to the OKD config example in README.md